### PR TITLE
Added (partial) support for `Dyson Pure Hot + Cool Link HP02`

### DIFF
--- a/src/dyson-pure-cool-platform.js
+++ b/src/dyson-pure-cool-platform.js
@@ -51,7 +51,7 @@ function DysonPureCoolPlatform(log, config, api) {
     platform.config.countryCode = platform.config.countryCode || 'US';
     platform.config.devices = platform.config.devices || [];
     platform.config.apiUri = 'https://api.cp.dyson.com';
-    platform.config.supportedProductTypes = ['438', '469', '475', '520'];
+    platform.config.supportedProductTypes = ['438', '455', '469', '475', '520'];
 
     // Checks whether the API object is available
     if (!api) {


### PR DESCRIPTION
It only exposes it as air purifiers, no heater features, but it's better than no support.