### PR TITLE
Increased max temperature to 38c

### DIFF
--- a/src/dyson-pure-cool-device.js
+++ b/src/dyson-pure-cool-device.js
@@ -257,7 +257,7 @@ function DysonPureCoolDevice(platform, name, serialNumber, productType, version,
     
             // Updates the target temperature for heating
             temperatureService.getCharacteristic(Characteristic.TargetTemperature).setProps({
-                maxValue: 37,
+                maxValue: 38,
                 minValue: 0,
                 minStep: 1,
                 unit: 'celsius'


### PR DESCRIPTION
The current max temperature of 37c causes an error with Dyson's on max temperature in Fahrenheit.  This PR updates the max from 37 to 38.