### PR TITLE
Add support for Hot+Cool Formaldehyde (527E)

### DIFF
--- a/src/dyson-pure-cool-device.js
+++ b/src/dyson-pure-cool-device.js
@@ -73,6 +73,13 @@ function DysonPureCoolDevice(platform, name, serialNumber, productType, version,
             hasAdvancedAirQualitySensors = true;
             hasHeating = true;
             break;
+        case '527E':
+            model = 'Dyson Purifier Hot+Cool Formaldehyde';
+            hardwareRevision = 'HP09';
+            hasJetFocus = true;
+            hasAdvancedAirQualitySensors = true;
+            hasHeating = true;
+            break;
     }
 
     // Checks if heating is disabled by the configuration

--- a/src/dyson-pure-cool-platform.js
+++ b/src/dyson-pure-cool-platform.js
@@ -52,7 +52,7 @@ function DysonPureCoolPlatform(log, config, api) {
     platform.config.countryCode = platform.config.countryCode || 'US';
     platform.config.devices = platform.config.devices || [];
     platform.config.apiUri = 'https://appapi.cp.dyson.com';
-    platform.config.supportedProductTypes = ['358', '438', '455', '469', '475', '520', '527'];
+    platform.config.supportedProductTypes = ['358', '438', '455', '469', '475', '520', '527', '527E'];
     platform.config.updateInterval = platform.config.updateInterval || (60 * 1000);
 
     // Checks whether the API object is available


### PR DESCRIPTION
- Set `model`, `hardwareRevision`, `hasJetFocus`, `hasAdvancedAirQualitySensors`, `hasHeating` when `productType` is `527E`.
- Add `527E` to supported product types