### PR TITLE
Add support for Cool+Humidify Formaldehyde 2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This project is a homebridge plugin for the Dyson air purifiers. Supported devic
 
 - Dyson Pure Humidify+Cool (PH01)
 - Dyson Pure Humidify+Cool Cryptomic (PH02)
+- Dyson Pure Humidify+Cool Formaldehyde (PH04)
 - Dyson Pure Cool Tower (TP04, TP07)
 - Dyson Pure Cool Tower Cryptomic (TP06)
 - Dyson Pure Cool Desk (DP04)

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,7 +1,7 @@
 {
     "pluginAlias": "DysonPureCoolPlatform",
     "pluginType": "platform",
-    "headerDisplay": "This plugin supports the Dyson Pure Cool (DP04, TP04, TP06, TP07), Dyson Pure Cool Link (DP01, TP02), Dyson Hot+Cool (HP02, HP04, HP06, HP09) and Dyson Pure Humidify+Cool (PH01, PH02) devices.",
+    "headerDisplay": "This plugin supports the Dyson Pure Cool (DP04, TP04, TP06, TP07), Dyson Pure Cool Link (DP01, TP02), Dyson Hot+Cool (HP02, HP04, HP06, HP09) and Dyson Pure Humidify+Cool (PH01, PH02, PH04) devices.",
     "footerDisplay": "For help please visit the [GitHub repository](https://github.com/lukasroegner/homebridge-dyson-pure-cool).",
     "schema": {
         "type": "object",
@@ -105,7 +105,7 @@
                             "title": "Full Range Humidity",
                             "type": "boolean",
                             "default": false,
-                            "description": "Only for PH01/PH02. If set to true, the range of the target humidity control will be from 0% to 100% instead of translating it to the allowed range (30% to 70%) of the Dyson."
+                            "description": "Only for PH01/PH02/PH04. If set to true, the range of the target humidity control will be from 0% to 100% instead of translating it to the allowed range (30% to 70%) of the Dyson."
                         },
                         "isHeatingDisabled": {
                             "title": "Disable Heating",

--- a/src/dyson-pure-cool-device.js
+++ b/src/dyson-pure-cool-device.js
@@ -40,6 +40,13 @@ function DysonPureCoolDevice(platform, name, serialNumber, productType, version,
             hasHumidifier = true;
             hasJetFocus = true;
             break;
+        case '358E':
+            model = 'Dyson Pure Humidify+Cool Formaldehyde';
+            hardwareRevision = 'PH02';
+            hasAdvancedAirQualitySensors = true;
+            hasHumidifier = true;
+            hasJetFocus = true;
+            break;
         case '438':
             model = 'Dyson Pure Cool Tower';
             hardwareRevision = 'TP04';
@@ -267,7 +274,7 @@ function DysonPureCoolDevice(platform, name, serialNumber, productType, version,
                 minValue: 0,
                 validValues: [0, 1]
             });
-    
+
             // Updates the target temperature for heating
             temperatureService.getCharacteristic(Characteristic.TargetTemperature).setProps({
                 maxValue: 38,
@@ -318,7 +325,7 @@ function DysonPureCoolDevice(platform, name, serialNumber, productType, version,
                 minValue: 0,
                 validValues: [0, 1]
             });
-    
+
             // Updates the humidity threshold
             if (config.isFullRangeHumidity) {
                 humidityService.getCharacteristic(Characteristic.RelativeHumidityHumidifierThreshold).setProps({
@@ -752,7 +759,7 @@ function DysonPureCoolDevice(platform, name, serialNumber, productType, version,
         if (config.enableOscillationWhenActivating) {
             commandData['oson'] = 'ON';
         }
-    
+
         // Executes the actual change of the active state
         platform.log.info(serialNumber + ' - set Active to ' + value + ': ' + JSON.stringify(commandData));
         device.mqttClient.publish(productType + '/' + serialNumber + '/command', JSON.stringify({

--- a/src/dyson-pure-cool-device.js
+++ b/src/dyson-pure-cool-device.js
@@ -42,7 +42,7 @@ function DysonPureCoolDevice(platform, name, serialNumber, productType, version,
             break;
         case '358E':
             model = 'Dyson Pure Humidify+Cool Formaldehyde';
-            hardwareRevision = 'PH02';
+            hardwareRevision = 'PH04';
             hasAdvancedAirQualitySensors = true;
             hasHumidifier = true;
             hasJetFocus = true;

--- a/src/dyson-pure-cool-platform.js
+++ b/src/dyson-pure-cool-platform.js
@@ -44,7 +44,7 @@ function DysonPureCoolPlatform(log, config, api) {
 
     // Initializes the configuration
     platform.config.devices = platform.config.devices || [];
-    platform.config.supportedProductTypes = ['358', '438', '438E', '455', '469', '475', '520', '527', '527E'];
+    platform.config.supportedProductTypes = ['358', '358E', '438', '438E', '455', '469', '475', '520', '527', '527E'];
     platform.config.updateInterval = platform.config.updateInterval || (60 * 1000);
     platform.config.credentialsGeneratorPort = platform.config.credentialsGeneratorPort || 48000;
 
@@ -77,7 +77,7 @@ function DysonPureCoolPlatform(log, config, api) {
         // Cycles over all devices from the config and tests whether the credentials can be parsed
         for (let i = 0; i < platform.config.devices.length; i++) {
             const config = platform.config.devices[i];
-    
+
             // Decodes the API configuration that has been stored
             try {
                 JSON.parse(Buffer.from(config.credentials.trim(), 'base64').toString('utf8'));
@@ -86,18 +86,18 @@ function DysonPureCoolPlatform(log, config, api) {
                 return;
             }
         }
-    
+
         // Cycles over all devices from the config and creates them
         for (let i = 0; i < platform.config.devices.length; i++) {
             const config = platform.config.devices[i];
-    
+
             // Decodes the API configuration that has been stored
             let apiConfig = JSON.parse(Buffer.from(config.credentials.trim(), 'base64').toString('utf8'));
-    
+
             // Creates the device instance and adds it to the list of all devices
             platform.devices.push(new DysonPureCoolDevice(platform, apiConfig.Name, apiConfig.Serial, apiConfig.ProductType, apiConfig.Version, apiConfig.password, config));
         }
-    
+
         // Removes the accessories that are not bound to a device
         let unusedAccessories = platform.accessories.filter(function(a) { return !platform.devices.some(function(d) { return d.serialNumber === a.context.serialNumber; }); });
         for (let i = 0; i < unusedAccessories.length; i++) {
@@ -106,7 +106,7 @@ function DysonPureCoolPlatform(log, config, api) {
             platform.accessories.splice(platform.accessories.indexOf(unusedAccessory), 1);
         }
         platform.api.unregisterPlatformAccessories(platform.pluginName, platform.platformName, unusedAccessories);
-    
+
         platform.log.info('Accessories initialized.');
     });
 


### PR DESCRIPTION
This PR adds support for Humidify+Cool Formaldehyde (2021 model).

The only change is to add `358E` to the list of supported product types with all the settings inherited from `358`, save for the model name. The changes were tested locally and appear to work fine.

VS Code has removed some trailing spaces from modified files, I noticed it late, sorry for that.