### PR TITLE
Attempt to support Fahrenheit step better

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -33,6 +33,12 @@
                             "required": true,
                             "description": "The credentials for connecting to the device. They can be retrieved via the credentials generator (website), please consult the README on how to retrieve the credentials."
                         },
+                        "useFahrenheit": {
+                            "title": "Use Fahrenheit for thermostat",
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If set to true, it will use Fahrenheit for temperature scale in the Home app."
+                        },
                         "enableAutoModeWhenActivating": {
                             "title": "Enable Auto Mode",
                             "type": "boolean",

--- a/src/dyson-pure-cool-device.js
+++ b/src/dyson-pure-cool-device.js
@@ -770,7 +770,6 @@ function DysonPureCoolDevice(platform, name, serialNumber, productType, version,
         });
         temperatureService.getCharacteristic(Characteristic.TargetTemperature).on('set', function (value, callback) {
             platform.log.info(serialNumber + ' - set TargetTemperature to ' + value + ': ' + JSON.stringify({ hmax: ('0000' + Math.round((value + 273.0) * 10.0).toString()).slice(-4) }));
-            console.log(value);
             device.mqttClient.publish(productType + '/' + serialNumber + '/command', JSON.stringify({
                 msg: 'STATE-SET',
                 time: new Date().toISOString(),

--- a/src/dyson-pure-cool-device.js
+++ b/src/dyson-pure-cool-device.js
@@ -14,6 +14,7 @@ const mqtt = require('mqtt');
 function DysonPureCoolDevice(platform, name, serialNumber, productType, version, password, config) {
     const device = this;
     const { UUIDGen, Accessory, Characteristic, Service } = platform;
+    const temperatureStep = config.useFahrenheit ? 0.555 : 1;
 
     // Stores the information of the device that is used for shutdown
     device.serialNumber = serialNumber;
@@ -207,7 +208,7 @@ function DysonPureCoolDevice(platform, name, serialNumber, productType, version,
             temperatureService.getCharacteristic(Characteristic.TargetTemperature).setProps({
                 maxValue: 38,
                 minValue: 0,
-                minStep: 1,
+                minStep: temperatureStep,
                 unit: 'celsius'
             });
         } else {
@@ -769,6 +770,7 @@ function DysonPureCoolDevice(platform, name, serialNumber, productType, version,
         });
         temperatureService.getCharacteristic(Characteristic.TargetTemperature).on('set', function (value, callback) {
             platform.log.info(serialNumber + ' - set TargetTemperature to ' + value + ': ' + JSON.stringify({ hmax: ('0000' + Math.round((value + 273.0) * 10.0).toString()).slice(-4) }));
+            console.log(value);
             device.mqttClient.publish(productType + '/' + serialNumber + '/command', JSON.stringify({
                 msg: 'STATE-SET',
                 time: new Date().toISOString(),


### PR DESCRIPTION
HomeKit only supports thermostat target temperature in Celsius which means standard step 1 C equals to about 1.5 F which sometimes can be noticed as step 2 F in Home app. This pull request adds support for smaller step for Fahrenheit users.

It was reported by users in #144 