### PR TITLE
Better support for Fahrenheit temperatures

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -116,6 +116,22 @@
                     }
                 }
             },
+            "temperatureUnit": {
+                "title": "Temperature Unit",
+                "type": "string",
+                "default": "celsius",
+                "oneOf": [
+                    {
+                        "title": "Celsius",
+                        "enum": ["celsius"]
+                    },
+                    {
+                        "title": "Fahrenheit",
+                        "enum": ["fahrenheit"]
+                    }
+                ],
+                "required": true
+            },
             "updateInterval": {
                 "title": "Update Interval",
                 "type": "integer",

--- a/src/dyson-pure-cool-device.js
+++ b/src/dyson-pure-cool-device.js
@@ -183,6 +183,8 @@ function DysonPureCoolDevice(platform, name, serialNumber, productType, version,
     if (!temperatureAccessory) {
         temperatureService = airPurifierService;
     } else {
+        const fahrenheit = (device.platform.config.temperatureUnit === 'fahrenheit');
+
         if (device.info.hasHeating) {
 
             // Uses a thermostat service
@@ -207,8 +209,7 @@ function DysonPureCoolDevice(platform, name, serialNumber, productType, version,
             temperatureService.getCharacteristic(Characteristic.TargetTemperature).setProps({
                 maxValue: 38,
                 minValue: 0,
-                minStep: 1,
-                unit: 'celsius'
+                minStep: fahrenheit ? 0.1 : 1,
             });
         } else {
 
@@ -218,6 +219,8 @@ function DysonPureCoolDevice(platform, name, serialNumber, productType, version,
                 temperatureService = temperatureAccessory.addService(Service.TemperatureSensor);
             }
         }
+
+        temperatureService.getCharacteristic(Characteristic.TemperatureDisplayUnits).updateValue(fahrenheit ? 1 : 0);
     }
 
     // Updates the temperature steps
@@ -226,7 +229,6 @@ function DysonPureCoolDevice(platform, name, serialNumber, productType, version,
         .setProps({
             minValue: -50,
             maxValue: 100,
-            unit: 'celsius'
         });
 
     // Updates the humidity sensor


### PR DESCRIPTION
I set up this plugin today and noticed I couldn't set the target temperature to 65 degrees Fahrenheit. I decided to look into it.
Currently, Fahrenheit temperatures are not properly supported. The min step of 1 celsius makes it impossible to set the target temperature to some values, like 65.
This PR fixes the issue by adding a new platform config `TemperatureUnit` and reducing the min step to 0.1 when it's set to `Fahrenheit`.