### PR TITLE
adding isHeatingSafetyIgnored configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [2.7.3] - 2022-03-13
+### Changes
+- Added a configuration option for the heating safety behavior introduced in `2.7.2`
+
 ## [2.7.2] - 2022-03-07
 ### Changes
 - Due to safety concerns, heating is now switch off when devices are switched on, which is the same behavior as in the Dyson app 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ This method seems to work for most people, see [#196](https://github.com/lukasro
                     "isAirQualityIgnored": false,
                     "isSingleAccessoryModeEnabled": false,
                     "isFullRangeHumidity": false,
-                    "isHeatingDisabled": false
+                    "isHeatingDisabled": false,
+                    "isHeatingSafetyIgnored": false
                 }
             ],
             "updateInterval": 60000,
@@ -182,6 +183,8 @@ This method seems to work for most people, see [#196](https://github.com/lukasro
 **isFullRangeHumidity**: Only for PH01/PH02. If set to `true`, the range of the target humidity control will be from 0% to 100% instead of translating it to the allowed range (30% to 70%) of the Dyson. Defaults to `false`.
 
 **isHeatingDisabled**: Only for HP02/HP04/HP06. If set to `true`, the heating controls are not exposed to HomeKit. Defaults to `false`.
+
+**isHeatingSafetyIgnored**: Only for HP02/HP04/HP06. If set to `true`, this overrides the default safety feature to allow heat to be turned on along with the fan if the fan was heating when last turned off. By default, the heat is disabled when turning on the fan in the Dyson app.
 
 **updateInterval** (optional): The interval (in milliseconds) at which updates of the sensors are requested from the Dyson devices. Defaults to 60 seconds.
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -158,6 +158,12 @@
                             "type": "boolean",
                             "default": false,
                             "description": "Only for HP02/HP04/HP06/HP07/HP09. If set to true, the heating controls are not exposed to HomeKit."
+                        },
+                        "isHeatingSafetyIgnored": {
+                            "title": "Heating Safety Behavior Ignored",
+                            "type": "boolean",
+                            "default": false,
+                            "description": "Only for HP02/HP04/HP06/HP07/HP09. If set to true, this overrides the default safety feature to allow heat to be turned on along with the fan if the fan was heating when last turned off. By default, the heat is disabled when turning on the fan in the Dyson app."
                         }
                     }
                 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-dyson-pure-cool",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "Plugin for using the Dyson Pure Cool fans in homebridge.",
   "license": "MIT",
   "keywords": [

--- a/src/dyson-pure-cool-device.js
+++ b/src/dyson-pure-cool-device.js
@@ -754,7 +754,7 @@ function DysonPureCoolDevice(platform, name, serialNumber, productType, version,
         }
 
         // The Dyson app disables heating when the device is turned on
-        if (value === Characteristic.Active.ACTIVE && device.info.hasHeating) {
+        if (value === Characteristic.Active.ACTIVE && device.info.hasHeating && !config.isHeatingSafetyIgnored) {
             commandData['hmod'] = 'OFF';
         }
 


### PR DESCRIPTION
See: [158](https://github.com/lukasroegner/homebridge-dyson-pure-cool/issues/158#issuecomment-1060293242)

and: https://github.com/lukasroegner/homebridge-dyson-pure-cool/commit/1842812e5afc2e6bc17b8fbd660f59b86a90e642#r68170750

Adding in a `isHeatingSafetyIgnored` configuration option to override the default safety behavior added in `2.7.2`. 

Essentially, if the heat was on when it was last turned off, if you turn on the fan again the heat should be on with this configuration option enabled. 