### PR TITLE
✨ support 527K

### DIFF
--- a/src/productTypeInfo.js
+++ b/src/productTypeInfo.js
@@ -59,6 +59,13 @@ const knownProducts = {
     hasAdvancedAirQualitySensors: true,
     hasHeating: true,
   },
+  '527K': {
+    model: 'Dyson Purifier Hot+Cool',
+    hardwareRevision: 'HP07',
+    hasJetFocus: true,
+    hasAdvancedAirQualitySensors: true,
+    hasHeating: true,
+  },
 };
 
 module.exports = function(productType) {


### PR DESCRIPTION
I recently bought dyson HP07 (white).
When I try to setup the component, the device is detected but the heating function cannot be displayed.

```
Serial: X3U-TW-XXXXXXXX
Name: bedroom
Device Type: 527K
Credential: XXXXXX
```

This pull request adds support for the 527K.