### PR TITLE
Adds auto mode switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ For humidifier devices, a humidifier is also exposes to HomeKit with support for
 
 Optionally, the following switches are exposed:
 - Night mode (on/off)
+- Auto mode (on/off)
 - Jet Focus (on/off; DP01, TP02, HP02, BP02, BP03, BP04 and BP06 are not supported)
 - Continuous Monitoring (on/off)
 
@@ -162,6 +163,8 @@ This method seems to work for most people, see [#196](https://github.com/lukasro
 **enableNightModeWhenActivating**: If set to `true`, night mode is enabled when you activate the device. Defaults to `false`.
 
 **isNightModeEnabled**: If set to `true`, a switch is exposed for the night mode. Defaults to `false`.
+
+**isAutoModeEnabled**: If set to `true`, a switch is exposed for the auto mode. Defaults to `false`.
 
 **isJetFocusEnabled**: If set to `true`, a switch is exposed for the jet focus. DP01, TP02 and HP02 are not supported. Defaults to `false`.
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -67,6 +67,13 @@
                             "required": true,
                             "description": "If set to true, a switch is exposed for the night mode."
                         },
+                        "isAutoModeEnabled": {
+                            "title": "Expose Auto Mode",
+                            "type": "boolean",
+                            "default": false,
+                            "required": true,
+                            "description": "If set to true, a switch is exposed for the auto mode."
+                        },
                         "isJetFocusEnabled": {
                             "title": "Expose Jet Focus",
                             "type": "boolean",

--- a/src/dyson-pure-cool-device.js
+++ b/src/dyson-pure-cool-device.js
@@ -116,7 +116,7 @@ function DysonPureCoolDevice(platform, name, serialNumber, productType, version,
 
     // Gets the switch accessory
     let switchAccessory = null;
-    if (config.isNightModeEnabled || config.isContinuousMonitoringEnabled || (config.isJetFocusEnabled && device.info.hasJetFocus)) {
+    if (config.isAutoModeEnabled || config.isNightModeEnabled || config.isContinuousMonitoringEnabled || (config.isJetFocusEnabled && device.info.hasJetFocus)) {
         if (config.isSingleAccessoryModeEnabled) {
             switchAccessory = airPurifierAccessory;
         } else {
@@ -319,6 +319,15 @@ function DysonPureCoolDevice(platform, name, serialNumber, productType, version,
         nightModeSwitchService = switchAccessory.getServiceById(Service.Switch, 'NightMode');
         if (!nightModeSwitchService) {
             nightModeSwitchService = switchAccessory.addService(Service.Switch, device.info.name + ' Night Mode', 'NightMode');
+        }
+    }
+
+    // Updates the auto mode
+    let autoModeSwitchService = null;
+    if (switchAccessory && config.isAutoModeEnabled) {
+        autoModeSwitchService = switchAccessory.getServiceByUUIDAndSubType(Service.Switch, 'AutoMode');
+        if (!autoModeSwitchService) {
+            autoModeSwitchService = switchAccessory.addService(Service.Switch, device.info.name + ' Auto Mode', 'AutoMode');
         }
     }
 
@@ -606,6 +615,11 @@ function DysonPureCoolDevice(platform, name, serialNumber, productType, version,
                 nightModeSwitchService.updateCharacteristic(Characteristic.On, content['product-state']['nmod'] !== 'OFF');
             }
 
+            // Sets the state of the auto mode switch
+            if (autoModeSwitchService) {
+                autoModeSwitchService.updateCharacteristic(Characteristic.On, content['product-state']['fmod'] === 'AUTO');
+            }
+
             // Sets the state of the jet focus switch
             if (jetFocusSwitchService) {
                 if (content['product-state']['fdir']) {
@@ -701,6 +715,11 @@ function DysonPureCoolDevice(platform, name, serialNumber, productType, version,
             // Sets the state of the night mode switch
             if (nightModeSwitchService) {
                 nightModeSwitchService.updateCharacteristic(Characteristic.On, content['product-state']['nmod'][1] !== 'OFF');
+            }
+
+            // Sets the state of the auto mode switch
+            if (autoModeSwitchService) {
+                autoModeSwitchService.updateCharacteristic(Characteristic.On, content['product-state']['fmod'][1] === 'AUTO');
             }
 
             // Sets the state of the jet focus switch
@@ -905,6 +924,33 @@ function DysonPureCoolDevice(platform, name, serialNumber, productType, version,
 
             // Sends the command
             platform.log.info(serialNumber + ' - set NightMode to ' + value + ': ' + JSON.stringify(commandData));
+            device.mqttClient.publish(productType + '/' + serialNumber + '/command', JSON.stringify({
+                msg: 'STATE-SET',
+                time: new Date().toISOString(),
+                data: commandData
+            }));
+            callback(null);
+        });
+    }
+
+    // Subscribes for changes of the auto mode
+    if (autoModeSwitchService) {
+        autoModeSwitchService.getCharacteristic(Characteristic.On).on('set', function (value, callback) {
+
+            // Builds the command data, if auto mode is set to ON, the device has to be ON
+            // If auto mode is set to OFF, the device status is not changed
+            let commandData = {};
+            if (value) {
+                commandData = { auto: 'ON', fmod: 'AUTO' }
+                if (!airPurifierService.getCharacteristic(Characteristic.Active).value) {
+                    commandData['fpwr'] = 'ON'
+                }
+            } else {
+                commandData = { auto: 'OFF', fmod: 'FAN' };
+            }
+
+            // Sends the command
+            platform.log.info(serialNumber + ' - set AutoMode to ' + value + ': ' + JSON.stringify(commandData));
             device.mqttClient.publish(productType + '/' + serialNumber + '/command', JSON.stringify({
                 msg: 'STATE-SET',
                 time: new Date().toISOString(),


### PR DESCRIPTION
Implemented exactly like the night mode switch, the auto mode switch allows toggling auto mode without changing any other settings.

My use case is that I like to run the fan on manual at high speed at night, then switch it to auto-mode during the day. Currently, I'm not able to automate the transition into auto mode because setting the accessory characteristics with a scene also sets the fan speed. With the auto mode switch, I can toggle just auto mode directly in automation.

Tested with a Dyson Pure Cool Link Desk (DP01). Not sure if the payloads differ on the other models -- happy to make changes if needed.