### PR TITLE
Fix crash for BP-series devices

### DIFF
--- a/src/dyson-pure-cool-device.js
+++ b/src/dyson-pure-cool-device.js
@@ -577,7 +577,9 @@ function DysonPureCoolDevice(platform, name, serialNumber, productType, version,
             }
 
             // Sets the rotation status
-            airPurifierService.updateCharacteristic(Characteristic.SwingMode, content['product-state']['oson'] === 'OFF' ? Characteristic.SwingMode.SWING_DISABLED : Characteristic.SwingMode.SWING_ENABLED);
+            if (device.info.hasOscillation) {
+                airPurifierService.updateCharacteristic(Characteristic.SwingMode, content['product-state']['oson'] === 'OFF' ? Characteristic.SwingMode.SWING_DISABLED : Characteristic.SwingMode.SWING_ENABLED);
+            }            
 
             // Sets the filter life
             if (content['product-state']['cflr'] && content['product-state']['hflr']) {
@@ -672,7 +674,9 @@ function DysonPureCoolDevice(platform, name, serialNumber, productType, version,
             }
 
             // Sets the rotation status
-            airPurifierService.updateCharacteristic(Characteristic.SwingMode, content['product-state']['oson'][1] === 'OFF' ? Characteristic.SwingMode.SWING_DISABLED : Characteristic.SwingMode.SWING_ENABLED);
+            if (device.info.hasOscillation) {
+                airPurifierService.updateCharacteristic(Characteristic.SwingMode, content['product-state']['oson'][1] === 'OFF' ? Characteristic.SwingMode.SWING_DISABLED : Characteristic.SwingMode.SWING_ENABLED);
+            }            
 
             // Sets the filter life
             if (content['product-state']['cflr'] && content['product-state']['hflr']) {
@@ -746,7 +750,7 @@ function DysonPureCoolDevice(platform, name, serialNumber, productType, version,
             fpwr: value === Characteristic.Active.INACTIVE ? 'OFF' : 'ON',
             fmod: value === Characteristic.Active.INACTIVE ? 'OFF' : activeMode
         };
-        if (config.enableOscillationWhenActivating) {
+        if (config.enableOscillationWhenActivating && device.info.hasOscillation) {
             commandData['oson'] = 'ON';
         }
         if (config.enableNightModeWhenActivating) {

--- a/src/productTypeInfo.js
+++ b/src/productTypeInfo.js
@@ -83,6 +83,7 @@ const knownProducts = {
     model: 'Dyson Purifier Big+Quiet Formaldehyde',
     hardwareRevision: 'BP02/BP03/BP04/BP06',
     hasAdvancedAirQualitySensors: true,
+    hasOscillation: false,
   },
 };
 
@@ -94,6 +95,7 @@ module.exports = function(productType) {
   if (!info.hasHeating) info.hasHeating = false;
   if (!info.hasHumidifier) info.hasHumidifier = false;
   if (!info.hasJetFocus) info.hasJetFocus = false;
+  if (!!info.hasOscillation) info.hasOscillation = true; // Assume most devices have oscillation - as of May 24' only BP-series don't
   if (!info.model) info.model = 'Pure Cool';
   return info;
 };


### PR DESCRIPTION
This pull request introduces crucial updates to the Homebridge-Dyson-Pure-Cool plugin to prevent crashes with Dyson devices that lack oscillation features, particularly the BP-series. The modifications add checks to ensure that oscillation controls are only invoked for devices that support this functionality and fixes crashes reported in #333 and #328.

**Key Changes:**

Conditional Oscillation Control: Modified the DysonPureCoolDevice logic to conditionally update the SwingMode characteristic based on the device's oscillation capability. This is done by wrapping oscillation control updates within an if (device.info.hasOscillation) check to prevent errors with non-oscillating devices.

Updated Device Information: Added a new attribute hasOscillation: false to the BP-series models in the knownProducts dictionary within productTypeInfo.js. This ensures that the system recognizes these devices as non-oscillating. It also assumes that most devices do have oscillation enabled, which is the case as of May '24.

Configurable Oscillation Behavior: Adjusted the handling of the enableOscillationWhenActivating configuration option to check for the hasOscillation flag before setting oscillation to 'ON'.