### PR TITLE
Fix 'Activate with Oscillation' feature

### DIFF
--- a/src/productTypeInfo.js
+++ b/src/productTypeInfo.js
@@ -95,7 +95,7 @@ module.exports = function(productType) {
   if (!info.hasHeating) info.hasHeating = false;
   if (!info.hasHumidifier) info.hasHumidifier = false;
   if (!info.hasJetFocus) info.hasJetFocus = false;
-  if (!!info.hasOscillation) info.hasOscillation = true; // Assume most devices have oscillation - as of May 24' only BP-series don't
+  if (!info.hasOscillation) info.hasOscillation = true; // Assume most devices have oscillation - as of May 24' only BP-series don't
   if (!info.model) info.model = 'Pure Cool';
   return info;
 };


### PR DESCRIPTION
Fix an issue in productTypeInfo that causes 'Activate with Oscillation' feature to stop working. Resolves #337.